### PR TITLE
Fix reconnectFromEarliestAvailableOffset

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -151,7 +151,7 @@ func (consumer *BrokerConsumer) reconnectFromEarliestAvailableOffset(conn *net.T
 	if err != nil {
 		return 0, err
 	}
-	return binary.BigEndian.Uint64(payload[0:]), nil
+	return binary.BigEndian.Uint64(payload[4:]), nil
 }
 
 // Consume makes a single fetch request and sends the messages in the message set to a handler function


### PR DESCRIPTION
According to https://cwiki.apache.org/confluence/display/KAFKA/Wire+Format the first 4 bytes of the response correspond to the number of offsets returned which in this case will be always 1. After that, it comes the actual offset.
So instead of doing a slice from `[0:]`, start at `[4:]`.

Also, Hi Lorenzo! :wave: :smiley: 